### PR TITLE
Adding Absolute File Paths to `Node.js` Backend

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "helmet": "^4.1.1",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.20",
+        "module-alias": "^2.2.2",
         "mongoose": "^5.10.11",
         "morgan": "^1.10.0",
         "passport": "^0.5.2",
@@ -8785,6 +8786,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
+      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "node_modules/moment": {
       "version": "2.29.1",
@@ -19738,6 +19744,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "module-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
+      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "moment": {
       "version": "2.29.1",

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,9 @@
   "resolutions": {
     "graceful-fs": "4.2.4"
   },
+  "_moduleAliases": {
+    "@src": "src"
+  },
   "private": true,
   "homepage": "https://github.com/kevinxu12/GrocerMe#readme",
   "dependencies": {
@@ -35,6 +38,7 @@
     "helmet": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.20",
+    "module-alias": "^2.2.2",
     "mongoose": "^5.10.11",
     "morgan": "^1.10.0",
     "passport": "^0.5.2",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,19 +3,21 @@
  * @file Main backend App
  * @author Kevin Xu
  */
+// Note that the module alias probably won't work with Jest. We will need relative file paths with Jest.
+import 'module-alias/register';
 import express from 'express';
 import bodyParser from 'body-parser';
 import cookieSession from 'cookie-session';
 import cors from 'cors';
-import { front_end_dev_cors_url } from './config';
-import logger from './core/logger';
+import { front_end_dev_cors_url } from '@src/config';
+import logger from '@src/core/logger';
 export { logger };
 
-import routesV1 from './routes/v1';
-import { initalizeSocket as initializeSocket, InternalSocketObjType } from './socket';
+import routesV1 from '@src/routes/v1';
+import { initalizeSocket as initializeSocket, InternalSocketObjType } from '@src/socket';
 import passport from 'passport';
-import { initializeS3Client } from './aws/s3';
-import morgan from './core/morgan';
+import { initializeS3Client } from '@src/aws/s3';
+import morgan from '@src/core/morgan';
 
 // initialize the mongo database
 require('./database');

--- a/server/src/auth/index.ts
+++ b/server/src/auth/index.ts
@@ -3,14 +3,14 @@
  * @author Kevin Xu
  */
 import passport from 'passport';
-import { RoleCode } from './../models/Role';
-import { BadRequestError } from './../core/ApiError';
-import UserRepo from './../repository/UserRepo';
-import User from './../models/User';
+import { RoleCode } from '@src/models/Role';
+import { BadRequestError } from '@src/core/ApiError';
+import UserRepo from '@src/repository/UserRepo';
+import User from '@src/models/User';
 import { Types } from 'mongoose';
 import { Profile } from 'passport-google-oauth20';
-import { google } from './../config';
-import { logger } from './../app';
+import { google } from '@src/config';
+import { logger } from '@src/app';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const GoogleStrategy = require('passport-google-oauth20').Strategy;

--- a/server/src/helpers/url.ts
+++ b/server/src/helpers/url.ts
@@ -2,7 +2,7 @@
  * @file generate url helpers
  * @author Kevin Xu
  */
-import { environment, front_end_dev_cors_url } from './../config';
+import { environment, front_end_dev_cors_url } from '@src/config';
 
 /**
  * Generate the correct frontend server url path to call an endpoint, given a relative path

--- a/server/src/repository/UserRepo.ts
+++ b/server/src/repository/UserRepo.ts
@@ -2,10 +2,10 @@
  * @file A helper client for all things related to the User model. The client is used before all else
  * @author Kevin Xu
  */
-import User, { UserModel } from './../models/User';
+import User, { UserModel } from '@src/models/User';
 import { Types } from 'mongoose';
-import Role, { RoleCode, RoleModel } from './../models/Role';
-import { InternalError } from './../core/ApiError';
+import Role, { RoleCode, RoleModel } from '@src/models/Role';
+import { InternalError } from '@src/core/ApiError';
 
 /**
  * The User client.

--- a/server/src/routes/v1/login/index.ts
+++ b/server/src/routes/v1/login/index.ts
@@ -4,12 +4,12 @@
  */
 import express from 'express';
 import passport from 'passport';
-import generateClientUrl from './../../../helpers/url';
-import { SuccessResponse } from './../../../core/ApiResponse';
-import User from './../../../models/User';
+import generateClientUrl from '@src/helpers/url';
+import { SuccessResponse } from '@src/core/ApiResponse';
+import User from '@src/models/User';
 
 // authenticate passport
-require('./../../../auth');
+require('@src/auth');
 
 const router = express.Router();
 

--- a/server/src/routes/v1/test/index.ts
+++ b/server/src/routes/v1/test/index.ts
@@ -4,11 +4,11 @@
  */
 import express from 'express';
 import { Socket } from 'socket.io';
-import User from './../../../models/User';
-import { SuccessMsgResponse } from '../../../core/ApiResponse';
-import asyncHandler from '../../../helpers/asyncHandler';
-import { ClientManagerType } from './../../../socket/ClientManager';
-import { logger } from './../../../app';
+import User from '@src/models/User';
+import { SuccessMsgResponse } from '@src/core/ApiResponse';
+import asyncHandler from '@src/helpers/asyncHandler';
+import { ClientManagerType } from '@src/socket/ClientManager';
+import { logger } from '@src/app';
 const router = express.Router();
 router.get(
   '/',

--- a/server/src/socket/ClientManager.ts
+++ b/server/src/socket/ClientManager.ts
@@ -3,7 +3,7 @@
  * @author Kevin Xu
  */
 import { Socket } from 'socket.io';
-import User from './../models/User';
+import User from '@src/models/User';
 
 export type ClientManagerType = {
   addClient: (client: Socket) => void;

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -2,13 +2,13 @@
  * @file Create a singular backend server
  * @author Kevin Xu
  */
-import ClientManager, { ClientManagerType } from './ClientManager';
+import ClientManager, { ClientManagerType } from '@src/socket/ClientManager';
 import { Server, Socket } from 'socket.io';
 import { createServer } from 'http';
 import { Application } from 'express';
-import { port, front_end_dev_cors_url } from './../config';
-import User from '~/models/User';
-import { logger } from './../app';
+import { port, front_end_dev_cors_url } from '@src/config';
+import User from '@src/models/User';
+import { logger } from '@src/app';
 
 export type InternalSocketObjType = {
   clientManager: ClientManagerType;

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -22,7 +22,7 @@
     "baseUrl": ".",
     "paths": {
       "*": ["node_modules/*", "src/types/*"],
-      "~/*": ["src/*"]
+      "@src/*": ["src/*"]
     }
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Before, the typescript compiler only worked for relative paths. Adding support for absolute paths. 
Note, as noted in the documentation, `module-alias` which makes this work may not work for Jest unit tests.